### PR TITLE
Support full-size notes field on Nano X

### DIFF
--- a/src/algo_tx.c
+++ b/src/algo_tx.c
@@ -106,8 +106,6 @@ encode_bin(uint8_t **p, uint8_t *e, uint8_t *bytes, int len)
   for (int i = 0; i < len; i++) {
     put_byte(p, e, bytes[i]);
   }
-
-  return;
 }
 
 static int

--- a/src/algo_tx.c
+++ b/src/algo_tx.c
@@ -94,14 +94,20 @@ encode_bin(uint8_t **p, uint8_t *e, uint8_t *bytes, int len)
   if (len < (1 << 8)) {
     put_byte(p, e, BIN8);
     put_byte(p, e, len);
-    for (int i = 0; i < len; i++) {
-      put_byte(p, e, bytes[i]);
-    }
-    return;
+  } else if (len < (1 << 16)) {
+    put_byte(p, e, BIN16);
+    put_byte(p, e, len >> 8);
+    put_byte(p, e, len & 0xFF);
+  } else {
+    // Longer binary blobs not suppported
+    os_sched_exit(0);
   }
 
-  // Longer binary blobs not suppported
-  os_sched_exit(0);
+  for (int i = 0; i < len; i++) {
+    put_byte(p, e, bytes[i]);
+  }
+
+  return;
 }
 
 static int

--- a/src/algo_tx.h
+++ b/src/algo_tx.h
@@ -54,6 +54,8 @@ struct txn_asset_config {
   struct asset_params params;
 };
 
+
+
 struct txn {
   enum TXTYPE type;
 
@@ -65,7 +67,12 @@ struct txn {
   char genesisID[32];
   uint8_t genesisHash[32];
 
+#if defined(TARGET_NANOX)
+  uint8_t note[1024];
+#else
   uint8_t note[32];
+#endif
+
   size_t note_len;
 
   // Fields for specific tx types

--- a/src/algo_tx.h
+++ b/src/algo_tx.h
@@ -54,8 +54,6 @@ struct txn_asset_config {
   struct asset_params params;
 };
 
-
-
 struct txn {
   enum TXTYPE type;
 

--- a/src/algo_tx_dec.c
+++ b/src/algo_tx_dec.c
@@ -102,12 +102,18 @@ static void
 decode_bin_var(uint8_t **bufp, uint8_t *buf_end, uint8_t *res, size_t *reslen, size_t reslenmax)
 {
   uint8_t b = next_byte(bufp, buf_end);
-  if (b != BIN8) {
+  uint16_t bin_len = 0;
+
+  if (b == BIN8) {
+    bin_len = next_byte(bufp, buf_end);
+  } else if (b == BIN16) {
+    bin_len = next_byte(bufp, buf_end);
+    bin_len = (bin_len << 8) | next_byte(bufp, buf_end);
+  } else {
     snprintf(decode_err, sizeof(decode_err), "expected bin, found %d", b);
     THROW(INVALID_PARAMETER);
   }
 
-  uint8_t bin_len = next_byte(bufp, buf_end);
   if (bin_len > reslenmax) {
     snprintf(decode_err, sizeof(decode_err), "expected <= %d bin bytes, found %d", reslenmax, bin_len);
     THROW(INVALID_PARAMETER);

--- a/src/main.c
+++ b/src/main.c
@@ -37,7 +37,11 @@ struct txn current_txn;
 /* A buffer for collecting msgpack-encoded transaction via APDUs,
  * as well as for msgpack-encoding transaction prior to signing.
  */
+#if defined(TARGET_NANOX)
+static uint8_t msgpack_buf[2048];
+#else
 static uint8_t msgpack_buf[1024];
+#endif
 static unsigned int msgpack_next_off;
 
 void

--- a/src/msgpack.h
+++ b/src/msgpack.h
@@ -7,6 +7,7 @@
 #define BOOL_FALSE  0xc2
 #define BOOL_TRUE   0xc3
 #define BIN8        0xc4
+#define BIN16       0xc5
 #define UINT8       0xcc
 #define UINT16      0xcd
 #define UINT32      0xce


### PR DESCRIPTION
The Nano X has significantly more memory than the Nano S, and so can support the full-sized notes field.