### PR TITLE
Clear private keys from memory when not in use

### DIFF
--- a/src/algo_keys.c
+++ b/src/algo_keys.c
@@ -2,16 +2,12 @@
 #include "cx.h"
 
 #include "algo_keys.h"
-
-// Allocate 64 bytes for privateKeyData because os_perso_derive_node_bip32
-// appears to write more than 32 bytes to this buffer.  However, we only
-// need 32 bytes for cx_ecfp_init_private_key..
-static uint8_t privateKeyData[64];
+#include <string.h>
 
 uint8_t publicKey[32];
 
-void
-algorand_key_derive(void)
+static void
+algorand_key_derive(uint8_t *privateKeyData)
 {
   uint32_t bip32Path[5];
 
@@ -26,7 +22,23 @@ algorand_key_derive(void)
 void
 algorand_private_key(cx_ecfp_private_key_t *privateKey)
 {
-  cx_ecfp_init_private_key(CX_CURVE_Ed25519, privateKeyData, 32, privateKey);
+  uint8_t privateKeyData[64];
+
+  // Zero out returned privateKey
+  explicit_bzero(privateKey, sizeof(*privateKey));
+
+  // Derive private key from internal master key, zero out intermediate private
+  // key data when done
+  BEGIN_TRY {
+    TRY {
+      algorand_key_derive(privateKeyData);
+      cx_ecfp_init_private_key(CX_CURVE_Ed25519, privateKeyData, 32, privateKey);
+    }
+    FINALLY {
+      explicit_bzero(privateKeyData, sizeof(privateKeyData));
+    }
+  }
+  END_TRY;
 }
 
 void
@@ -35,8 +47,24 @@ algorand_public_key(uint8_t *buf)
   cx_ecfp_private_key_t privateKey;
   cx_ecfp_public_key_t publicKey;
 
+  // Zero out return buf and publicKey to be computed (in case there is an
+  // exception before publicKey is filled in)
+  explicit_bzero(buf, 32);
+  explicit_bzero(&publicKey, sizeof(publicKey));
+
+  // Generate private key
   algorand_private_key(&privateKey);
-  cx_ecfp_generate_pair(CX_CURVE_Ed25519, &publicKey, &privateKey, 1);
+
+  // Attempt to convert private key to public key, zero out privateKey
+  BEGIN_TRY {
+    TRY {
+      cx_ecfp_generate_pair(CX_CURVE_Ed25519, &publicKey, &privateKey, 1);
+    }
+    FINALLY {
+      explicit_bzero(&privateKey, sizeof(privateKey));
+    }
+  }
+  END_TRY;
 
   // publicKey.W is 65 bytes: a header byte, followed by a 32-byte
   // x coordinate, followed by a 32-byte y coordinate.  The bytes

--- a/src/algo_keys.c
+++ b/src/algo_keys.c
@@ -52,12 +52,11 @@ algorand_public_key(uint8_t *buf)
   explicit_bzero(buf, 32);
   explicit_bzero(&publicKey, sizeof(publicKey));
 
-  // Generate private key
-  algorand_private_key(&privateKey);
-
   // Attempt to convert private key to public key, zero out privateKey
   BEGIN_TRY {
     TRY {
+      // Generate private key
+      algorand_private_key(&privateKey);
       cx_ecfp_generate_pair(CX_CURVE_Ed25519, &publicKey, &privateKey, 1);
     }
     FINALLY {

--- a/src/algo_keys.c
+++ b/src/algo_keys.c
@@ -23,6 +23,9 @@ algorand_key_derive(uint8_t *privateKeyData)
 void
 algorand_private_key(cx_ecfp_private_key_t *privateKey)
 {
+  // Allocate 64 bytes for privateKeyData because os_perso_derive_node_bip32
+  // appears to write more than 32 bytes to this buffer.  However, we only
+  // need 32 bytes for cx_ecfp_init_private_key...
   uint8_t privateKeyData[64];
 
   // Zero out returned privateKey

--- a/src/algo_keys.c
+++ b/src/algo_keys.c
@@ -52,10 +52,9 @@ algorand_public_key(uint8_t *buf)
   explicit_bzero(buf, 32);
   explicit_bzero(&publicKey, sizeof(publicKey));
 
-  // Attempt to convert private key to public key, zero out privateKey
+  // Attempt to convert private key to public key, zero out privateKey after
   BEGIN_TRY {
     TRY {
-      // Generate private key
       algorand_private_key(&privateKey);
       cx_ecfp_generate_pair(CX_CURVE_Ed25519, &publicKey, &privateKey, 1);
     }

--- a/src/algo_keys.c
+++ b/src/algo_keys.c
@@ -1,8 +1,9 @@
+#include <string.h>
+
 #include "os.h"
 #include "cx.h"
 
 #include "algo_keys.h"
-#include <string.h>
 
 uint8_t publicKey[32];
 

--- a/src/algo_keys.h
+++ b/src/algo_keys.h
@@ -2,6 +2,5 @@
 
 extern uint8_t publicKey[32];
 
-void algorand_key_derive(void);
 void algorand_private_key(cx_ecfp_private_key_t *privateKey);
 void algorand_public_key(uint8_t *buf);

--- a/src/algo_tx.c
+++ b/src/algo_tx.c
@@ -9,7 +9,11 @@ put_byte(uint8_t **p, uint8_t *e, uint8_t b)
 {
   if (*p < e) {
     *((*p)++) = b;
+    return;
   }
+
+  // Output buffer too short, caller should handle
+  THROW(0x6760);
 }
 
 static void

--- a/src/main.c
+++ b/src/main.c
@@ -62,12 +62,12 @@ txn_approve()
       algorand_private_key(&privateKey);
 
       int sig_len = cx_eddsa_sign(&privateKey,
-          0, CX_SHA512,
-          &msgpack_buf[0], msg_len,
-          NULL, 0,
-          G_io_apdu_buffer,
-          6+2*(32+1), // Formerly from cx_compliance_141.c
-          NULL);
+                                  0, CX_SHA512,
+                                  &msgpack_buf[0], msg_len,
+                                  NULL, 0,
+                                  G_io_apdu_buffer,
+                                  6+2*(32+1), // Formerly from cx_compliance_141.c
+                                  NULL);
 
       tx = sig_len;
       G_io_apdu_buffer[tx++] = 0x90;


### PR DESCRIPTION
Ledger audited our code and made a couple comments about best practices. In particular, they want us to zero out private keys in memory when they're not being used.

This PR addresses that feedback by lazily deriving private keys and clearing them from memory when we're done. I attempted to follow the best practices [outlined here](https://ledger.readthedocs.io/en/latest/additional/security_guidelines.html#private-key-management).

Additionally, they thought `put_byte` should throw instead of silently failing -- this seemed like a reasonable idea so I added exception handling into `txn_approve` (mostly copied from the main event look error handling, hence the weird `sw` variable).