### PR TITLE
Don't call UX_CALLBACK_SET_INTERVAL on Ledger X

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -111,8 +111,10 @@ algorand_main(void)
 
   msgpack_next_off = 0;
 
+#if defined(TARGET_NANOS)
   // next timer callback in 500 ms
   UX_CALLBACK_SET_INTERVAL(500);
+#endif
 
 #if defined(TARGET_NANOX)
   // enable bluetooth on nano x
@@ -316,10 +318,12 @@ io_event(unsigned char channel)
 
   case SEPROXYHAL_TAG_TICKER_EVENT:
     UX_TICKER_EVENT(G_io_seproxyhal_spi_buffer, {
+#if defined(TARGET_NANOS)
         // defaulty retrig very soon (will be overriden during
         // stepper_prepro)
         UX_CALLBACK_SET_INTERVAL(500);
         UX_REDISPLAY();
+#endif
     });
     break;
 


### PR DESCRIPTION
This was an oversight when making the UX changes for the Ledger X. The symptom was that sometimes during Bluetooth pairing, the app's `ui_idle` flow would overwrite the display when the user was trying to view the confirmation code.

I also ifdef'd out the `UX_REDISPLAY` called for the `SEPROXYHAL_TAG_TICKER_EVENT`, which matches the [ledger boilerplate example](https://github.com/LedgerHQ/ledger-app-boilerplate/blob/e84270ab07b276ad1c18370961d4efddc1058db4/src/main.c#L195).