### PR TITLE
Revert key clearing changes, match ledgerhq/master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ include $(BOLOS_SDK)/Makefile.glyphs
 # Main app configuration
 
 APPNAME = "Algorand"
-APPVERSION = 1.0.3
+APPVERSION = 1.0.6
 APP_LOAD_PARAMS = --appFlags 0x250 $(COMMON_LOAD_PARAMS)
 APP_LOAD_PARAMS += --path "44'/283'"
 
@@ -64,11 +64,11 @@ else
         DEFINES   += PRINTF\(...\)=
 endif
 
-DEFINES += HAVE_IO_USB HAVE_L4_USBLIB IO_USB_MAX_ENDPOINTS=7 IO_HID_EP_LENGTH=64 HAVE_USB_APDU
+DEFINES += HAVE_IO_USB HAVE_L4_USBLIB IO_USB_MAX_ENDPOINTS=4 IO_HID_EP_LENGTH=64 HAVE_USB_APDU
 
-# Support for WebUSB transport
-WEBUSB_URL = ledger-app.algorand.com
-DEFINES += HAVE_WEBUSB WEBUSB_URL_SIZE_B=$(shell echo -n $(WEBUSB_URL) | wc -c) WEBUSB_URL=$(shell echo -n $(WEBUSB_URL) | sed -e "s/./\\\'\0\\\',/g")
+#WEBUSB_URL = ledger-app.algorand.com
+#DEFINES += HAVE_WEBUSB WEBUSB_URL_SIZE_B=$(shell echo -n $(WEBUSB_URL) | wc -c) WEBUSB_URL=$(shell echo -n $(WEBUSB_URL) | sed -e "s/./\\\'\0\\\',/g")
+DEFINES   += HAVE_WEBUSB WEBUSB_URL_SIZE_B=0 WEBUSB_URL=""
 
 # Support for U2F transport
 DEFINES += HAVE_U2F HAVE_IO_U2F U2F_PROXY_MAGIC=\"algo\" USB_SEGMENT_SIZE=64 BLE_SEGMENT_SIZE=32

--- a/src/algo_keys.c
+++ b/src/algo_keys.c
@@ -1,14 +1,17 @@
-#include <string.h>
-
 #include "os.h"
 #include "cx.h"
 
 #include "algo_keys.h"
 
+// Allocate 64 bytes for privateKeyData because os_perso_derive_node_bip32
+// appears to write more than 32 bytes to this buffer.  However, we only
+// need 32 bytes for cx_ecfp_init_private_key..
+static uint8_t privateKeyData[64];
+
 uint8_t publicKey[32];
 
-static void
-algorand_key_derive(uint8_t *privateKeyData)
+void
+algorand_key_derive(void)
 {
   uint32_t bip32Path[5];
 
@@ -23,26 +26,7 @@ algorand_key_derive(uint8_t *privateKeyData)
 void
 algorand_private_key(cx_ecfp_private_key_t *privateKey)
 {
-  // Allocate 64 bytes for privateKeyData because os_perso_derive_node_bip32
-  // appears to write more than 32 bytes to this buffer.  However, we only
-  // need 32 bytes for cx_ecfp_init_private_key...
-  uint8_t privateKeyData[64];
-
-  // Zero out returned privateKey
-  explicit_bzero(privateKey, sizeof(*privateKey));
-
-  // Derive private key from internal master key, zero out intermediate private
-  // key data when done
-  BEGIN_TRY {
-    TRY {
-      algorand_key_derive(privateKeyData);
-      cx_ecfp_init_private_key(CX_CURVE_Ed25519, privateKeyData, 32, privateKey);
-    }
-    FINALLY {
-      explicit_bzero(privateKeyData, sizeof(privateKeyData));
-    }
-  }
-  END_TRY;
+  cx_ecfp_init_private_key(CX_CURVE_Ed25519, privateKeyData, 32, privateKey);
 }
 
 void
@@ -51,22 +35,8 @@ algorand_public_key(uint8_t *buf)
   cx_ecfp_private_key_t privateKey;
   cx_ecfp_public_key_t publicKey;
 
-  // Zero out return buf and publicKey to be computed (in case there is an
-  // exception before publicKey is filled in)
-  explicit_bzero(buf, 32);
-  explicit_bzero(&publicKey, sizeof(publicKey));
-
-  // Attempt to convert private key to public key, zero out privateKey after
-  BEGIN_TRY {
-    TRY {
-      algorand_private_key(&privateKey);
-      cx_ecfp_generate_pair(CX_CURVE_Ed25519, &publicKey, &privateKey, 1);
-    }
-    FINALLY {
-      explicit_bzero(&privateKey, sizeof(privateKey));
-    }
-  }
-  END_TRY;
+  algorand_private_key(&privateKey);
+  cx_ecfp_generate_pair(CX_CURVE_Ed25519, &publicKey, &privateKey, 1);
 
   // publicKey.W is 65 bytes: a header byte, followed by a 32-byte
   // x coordinate, followed by a 32-byte y coordinate.  The bytes

--- a/src/algo_keys.h
+++ b/src/algo_keys.h
@@ -2,5 +2,6 @@
 
 extern uint8_t publicKey[32];
 
+void algorand_key_derive(void);
 void algorand_private_key(cx_ecfp_private_key_t *privateKey);
 void algorand_public_key(uint8_t *buf);

--- a/src/algo_tx.c
+++ b/src/algo_tx.c
@@ -9,11 +9,7 @@ put_byte(uint8_t **p, uint8_t *e, uint8_t b)
 {
   if (*p < e) {
     *((*p)++) = b;
-    return;
   }
-
-  // Output buffer too short, caller should handle
-  THROW(0x6760);
 }
 
 static void

--- a/src/main.c
+++ b/src/main.c
@@ -48,53 +48,32 @@ void
 txn_approve()
 {
   unsigned int tx = 0;
+
   unsigned int msg_len;
+
+  msgpack_buf[0] = 'T';
+  msgpack_buf[1] = 'X';
+  msg_len = 2 + tx_encode(&current_txn, msgpack_buf+2, sizeof(msgpack_buf)-2);
+
+  PRINTF("Signing message: %.*h\n", msg_len, msgpack_buf);
+
   cx_ecfp_private_key_t privateKey;
-  volatile unsigned short sw = 0;
+  algorand_private_key(&privateKey);
 
-  BEGIN_TRY {
-    TRY {
-      msgpack_buf[0] = 'T';
-      msgpack_buf[1] = 'X';
-      msg_len = 2 + tx_encode(&current_txn, msgpack_buf+2, sizeof(msgpack_buf)-2);
-      PRINTF("Signing message: %.*h\n", msg_len, msgpack_buf);
+  int sig_len = cx_eddsa_sign(&privateKey,
+                              0, CX_SHA512,
+                              &msgpack_buf[0], msg_len,
+                              NULL, 0,
+                              G_io_apdu_buffer,
+                              6+2*(32+1), // Formerly from cx_compliance_141.c
+                              NULL);
 
-      algorand_private_key(&privateKey);
+  tx = sig_len;
+  G_io_apdu_buffer[tx++] = 0x90;
+  G_io_apdu_buffer[tx++] = 0x00;
 
-      int sig_len = cx_eddsa_sign(&privateKey,
-                                  0, CX_SHA512,
-                                  &msgpack_buf[0], msg_len,
-                                  NULL, 0,
-                                  G_io_apdu_buffer,
-                                  6+2*(32+1), // Formerly from cx_compliance_141.c
-                                  NULL);
-
-      tx = sig_len;
-      G_io_apdu_buffer[tx++] = 0x90;
-      G_io_apdu_buffer[tx++] = 0x00;
-    }
-    CATCH_OTHER(e) {
-      // Report error code
-      switch (e & 0xF000) {
-      case 0x6000:
-      case 0x9000:
-        sw = e;
-        break;
-      default:
-        sw = 0x6800 | (e & 0x7FF);
-        break;
-      }
-      tx = 0;
-      G_io_apdu_buffer[tx++] = (sw >> 8) & 0xFF;
-      G_io_apdu_buffer[tx++] = sw & 0xFF;
-    }
-    FINALLY {
-      explicit_bzero(&privateKey, sizeof(privateKey));
-      // Send back the response, do not restart the event loop
-      io_exchange(CHANNEL_APDU | IO_RETURN_AFTER_TX, tx);
-    }
-  }
-  END_TRY;
+  // Send back the response, do not restart the event loop
+  io_exchange(CHANNEL_APDU | IO_RETURN_AFTER_TX, tx);
 
   // Display back the original UX
   ui_idle();
@@ -127,6 +106,7 @@ algorand_main(void)
   volatile unsigned int tx = 0;
   volatile unsigned int flags = 0;
 
+  algorand_key_derive();
   algorand_public_key(publicKey);
 
   msgpack_next_off = 0;
@@ -296,8 +276,8 @@ algorand_main(void)
           break;
         }
         // Unexpected exception => report
-        G_io_apdu_buffer[tx] = (sw >> 8) & 0xFF;
-        G_io_apdu_buffer[tx + 1] = sw & 0xFF;
+        G_io_apdu_buffer[tx] = sw >> 8;
+        G_io_apdu_buffer[tx + 1] = sw;
         tx += 2;
       }
       FINALLY {


### PR DESCRIPTION
We didn't end up releasing the key clearing changes because they broke U2F on the Nano S. I don't want us to be out of sync with ledger's branch, so this reverts those changes and also syncs our `Makefile` with theirs.