### PR TITLE
Add missing keyreg fields, add rekey field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,13 +94,13 @@ $(info GCCPATH is not set: arm-none-eabi-* will be used from PATH)
 endif
 
 CC := $(CLANGPATH)clang
-CFLAGS += -O3 -Os
+CFLAGS += -O3 -Oz
 
 AS := $(GCCPATH)arm-none-eabi-gcc
 AFLAGS +=
 
 LD := $(GCCPATH)arm-none-eabi-gcc
-LDFLAGS += -O3 -Os
+LDFLAGS += -O3 -Oz
 LDLIBS += -lm -lgcc -lc
 
 # Main rules

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ include $(BOLOS_SDK)/Makefile.glyphs
 # Main app configuration
 
 APPNAME = "Algorand"
-APPVERSION = 1.0.7
+APPVERSION = 1.0.8
 APP_LOAD_PARAMS = --appFlags 0x250 $(COMMON_LOAD_PARAMS)
 APP_LOAD_PARAMS += --path "44'/283'"
 

--- a/src/algo_tx.c
+++ b/src/algo_tx.c
@@ -263,12 +263,16 @@ tx_encode(struct txn *t, uint8_t *buf, int buflen)
   buf[0] +=                 map_kv_str   (&p, e, "gen",     t->genesisID, sizeof(t->genesisID));
   buf[0] +=                 map_kv_bin   (&p, e, "gh",      t->genesisHash, sizeof(t->genesisHash));
   buf[0] +=                 map_kv_uint64(&p, e, "lv",      t->lastValid);
+  buf[0] += T(KEYREG,       map_kv_bool  (&p, e, "nonpart", t->keyreg.nonpartFlag));
   buf[0] +=                 map_kv_bin   (&p, e, "note",    t->note, t->note_len);
   buf[0] += T(PAYMENT,      map_kv_bin   (&p, e, "rcv",     t->payment.receiver, sizeof(t->payment.receiver)));
   buf[0] += T(KEYREG,       map_kv_bin   (&p, e, "selkey",  t->keyreg.vrfpk, sizeof(t->keyreg.vrfpk)));
   buf[0] +=                 map_kv_bin   (&p, e, "snd",     t->sender, sizeof(t->sender));
   buf[0] +=                 map_kv_str   (&p, e, "type",    typestr, SIZE_MAX);
+  buf[0] += T(KEYREG,       map_kv_uint64(&p, e, "votefst", t->keyreg.voteFirst));
+  buf[0] += T(KEYREG,       map_kv_uint64(&p, e, "votekd",  t->keyreg.keyDilution));
   buf[0] += T(KEYREG,       map_kv_bin   (&p, e, "votekey", t->keyreg.votepk, sizeof(t->keyreg.votepk)));
+  buf[0] += T(KEYREG,       map_kv_uint64(&p, e, "votelst", t->keyreg.voteLast));
   buf[0] += T(ASSET_XFER,   map_kv_uint64(&p, e, "xaid",    t->asset_xfer.id));
 
 #undef T

--- a/src/algo_tx.c
+++ b/src/algo_tx.c
@@ -266,6 +266,7 @@ tx_encode(struct txn *t, uint8_t *buf, int buflen)
   buf[0] += T(KEYREG,       map_kv_bool  (&p, e, "nonpart", t->keyreg.nonpartFlag));
   buf[0] +=                 map_kv_bin   (&p, e, "note",    t->note, t->note_len);
   buf[0] += T(PAYMENT,      map_kv_bin   (&p, e, "rcv",     t->payment.receiver, sizeof(t->payment.receiver)));
+  buf[0] +=                 map_kv_bin   (&p, e, "rekey",   t->rekey, sizeof(t->rekey));
   buf[0] += T(KEYREG,       map_kv_bin   (&p, e, "selkey",  t->keyreg.vrfpk, sizeof(t->keyreg.vrfpk)));
   buf[0] +=                 map_kv_bin   (&p, e, "snd",     t->sender, sizeof(t->sender));
   buf[0] +=                 map_kv_str   (&p, e, "type",    typestr, SIZE_MAX);

--- a/src/algo_tx.h
+++ b/src/algo_tx.h
@@ -63,6 +63,7 @@ struct txn {
 
   // Common header fields
   uint8_t sender[32];
+  uint8_t rekey[32];
   uint64_t fee;
   uint64_t firstValid;
   uint64_t lastValid;

--- a/src/algo_tx.h
+++ b/src/algo_tx.h
@@ -71,7 +71,7 @@ struct txn {
   uint8_t genesisHash[32];
 
 #if defined(TARGET_NANOX)
-  uint8_t note[1024];
+  uint8_t note[512];
 #else
   uint8_t note[32];
 #endif

--- a/src/algo_tx.h
+++ b/src/algo_tx.h
@@ -33,6 +33,10 @@ struct txn_payment {
 struct txn_keyreg {
   uint8_t votepk[32];
   uint8_t vrfpk[32];
+  uint64_t voteFirst;
+  uint64_t voteLast;
+  uint64_t keyDilution;
+  uint8_t nonpartFlag;
 };
 
 struct txn_asset_xfer {

--- a/src/algo_tx_dec.c
+++ b/src/algo_tx_dec.c
@@ -252,6 +252,8 @@ tx_decode(uint8_t *buf, int buflen, struct txn *t)
           }
         } else if (!strcmp(key, "snd")) {
           decode_bin_fixed(&buf, buf_end, t->sender, sizeof(t->sender));
+        } else if (!strcmp(key, "rekey")) {
+          decode_bin_fixed(&buf, buf_end, t->rekey, sizeof(t->rekey));
         } else if (!strcmp(key, "fee")) {
           decode_uint64(&buf, buf_end, &t->fee);
         } else if (!strcmp(key, "fv")) {

--- a/src/algo_tx_dec.c
+++ b/src/algo_tx_dec.c
@@ -274,6 +274,14 @@ tx_decode(uint8_t *buf, int buflen, struct txn *t)
           decode_bin_fixed(&buf, buf_end, t->keyreg.vrfpk, sizeof(t->keyreg.vrfpk));
         } else if (!strcmp(key, "votekey")) {
           decode_bin_fixed(&buf, buf_end, t->keyreg.votepk, sizeof(t->keyreg.votepk));
+        } else if (!strcmp(key, "votefst")) {
+          decode_uint64(&buf, buf_end, &t->keyreg.voteFirst);
+        } else if (!strcmp(key, "votelst")) {
+          decode_uint64(&buf, buf_end, &t->keyreg.voteLast);
+        } else if (!strcmp(key, "votekd")) {
+          decode_uint64(&buf, buf_end, &t->keyreg.keyDilution);
+        } else if (!strcmp(key, "nonpart")) {
+          decode_bool(&buf, buf_end, &t->keyreg.nonpartFlag);
         } else if (!strcmp(key, "aamt")) {
           decode_uint64(&buf, buf_end, &t->asset_xfer.amount);
         } else if (!strcmp(key, "aclose")) {

--- a/src/ui_txn.c
+++ b/src/ui_txn.c
@@ -201,11 +201,11 @@ static int step_votelast() {
   return 1;
 }
 
-static int step_nonpart() {
+static int step_participating() {
   if (current_txn.keyreg.nonpartFlag) {
-    ui_text_put("True");
+    ui_text_put("No");
   } else {
-    ui_text_put("False");
+    ui_text_put("Yes");
   }
   return 1;
 }
@@ -400,11 +400,11 @@ ALGO_UX_STEP_NOCB_INIT(PAYMENT, 9,  bnnn_paging, step_receiver(), {"Receiver",  
 ALGO_UX_STEP_NOCB_INIT(PAYMENT, 10, bn,          step_amount(),   {"Amount (uAlg)", text});
 ALGO_UX_STEP_NOCB_INIT(PAYMENT, 11, bnnn_paging, step_close(),    {"Close to",      text});
 
-ALGO_UX_STEP_NOCB_INIT(KEYREG, 12, bnnn_paging, step_votepk(),    {"Vote PK",          text});
-ALGO_UX_STEP_NOCB_INIT(KEYREG, 13, bnnn_paging, step_vrfpk(),     {"VRF PK",           text});
-ALGO_UX_STEP_NOCB_INIT(KEYREG, 14, bn,          step_votefirst(), {"Vote first",       text});
-ALGO_UX_STEP_NOCB_INIT(KEYREG, 15, bn,          step_votelast(),  {"Vote last",        text});
-ALGO_UX_STEP_NOCB_INIT(KEYREG, 16, bn,          step_nonpart(),   {"Nonparticipating", text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 12, bnnn_paging, step_votepk(),        {"Vote PK",       text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 13, bnnn_paging, step_vrfpk(),         {"VRF PK",        text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 14, bn,          step_votefirst(),     {"Vote first",    text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 15, bn,          step_votelast(),      {"Vote last",     text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 16, bn,          step_participating(), {"Participating", text});
 
 ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 17, bn,          step_asset_xfer_id(),       {"Asset ID",   text});
 ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 18, bn,          step_asset_xfer_amount(),   {"Asset amt",   text});
@@ -505,7 +505,7 @@ static const struct ux_step ux_steps[] = {
   { KEYREG,       "VRF PK",           &step_vrfpk },
   { KEYREG,       "Vote first",       &step_votefirst },
   { KEYREG,       "Vote last",        &step_votelast },
-  { KEYREG,       "Nonparticipating", &step_nonpart },
+  { KEYREG,       "Participating",    &step_participating },
   { ASSET_XFER,   "Asset ID",         &step_asset_xfer_id },
   { ASSET_XFER,   "Asset amt",        &step_asset_xfer_amount },
   { ASSET_XFER,   "Asset src",        &step_asset_xfer_sender },

--- a/src/ui_txn.c
+++ b/src/ui_txn.c
@@ -180,6 +180,25 @@ static int step_vrfpk() {
   return 1;
 }
 
+static int step_votefirst() {
+  ui_text_put(u64str(current_txn.keyreg.voteFirst));
+  return 1;
+}
+
+static int step_votelast() {
+  ui_text_put(u64str(current_txn.keyreg.voteLast));
+  return 1;
+}
+
+static int step_nonpart() {
+  if (current_txn.keyreg.nonpartFlag) {
+    ui_text_put("True");
+  } else {
+    ui_text_put("False");
+  }
+  return 1;
+}
+
 static int step_asset_xfer_id() {
   ui_text_put(u64str(current_txn.asset_xfer.id));
   return 1;
@@ -369,34 +388,37 @@ ALGO_UX_STEP_NOCB_INIT(PAYMENT, 8,  bnnn_paging, step_receiver(), {"Receiver",  
 ALGO_UX_STEP_NOCB_INIT(PAYMENT, 9,  bn,          step_amount(),   {"Amount (uAlg)", text});
 ALGO_UX_STEP_NOCB_INIT(PAYMENT, 10, bnnn_paging, step_close(),    {"Close to",      text});
 
-ALGO_UX_STEP_NOCB_INIT(KEYREG, 11, bnnn_paging, step_votepk(), {"Vote PK", text});
-ALGO_UX_STEP_NOCB_INIT(KEYREG, 12, bnnn_paging, step_vrfpk(),  {"VRF PK",  text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 11, bnnn_paging, step_votepk(),    {"Vote PK",          text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 12, bnnn_paging, step_vrfpk(),     {"VRF PK",           text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 13, bn,          step_votefirst(), {"Vote first",       text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 14, bn,          step_votelast(),  {"Vote last",        text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 15, bn,          step_nonpart(),   {"Nonparticipating", text});
 
-ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 13, bn,          step_asset_xfer_id(),       {"Asset ID",   text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 14, bn,          step_asset_xfer_amount(),   {"Asset amt",   text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 15, bnnn_paging, step_asset_xfer_sender(),   {"Asset src",   text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 16, bnnn_paging, step_asset_xfer_receiver(), {"Asset dst",   text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 17, bnnn_paging, step_asset_xfer_close(),    {"Asset close", text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 16, bn,          step_asset_xfer_id(),       {"Asset ID",   text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 17, bn,          step_asset_xfer_amount(),   {"Asset amt",   text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 18, bnnn_paging, step_asset_xfer_sender(),   {"Asset src",   text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 19, bnnn_paging, step_asset_xfer_receiver(), {"Asset dst",   text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 20, bnnn_paging, step_asset_xfer_close(),    {"Asset close", text});
 
-ALGO_UX_STEP_NOCB_INIT(ASSET_FREEZE, 18, bn,          step_asset_freeze_id(),      {"Asset ID",      text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_FREEZE, 19, bnnn_paging, step_asset_freeze_account(), {"Asset account", text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_FREEZE, 20, bn,          step_asset_freeze_flag(),    {"Freeze flag",   text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_FREEZE, 21, bn,          step_asset_freeze_id(),      {"Asset ID",      text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_FREEZE, 22, bnnn_paging, step_asset_freeze_account(), {"Asset account", text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_FREEZE, 23, bn,          step_asset_freeze_flag(),    {"Freeze flag",   text});
 
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 21, bn,          step_asset_config_id(),             {"Asset ID",       text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 22, bn,          step_asset_config_total(),          {"Total units",    text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 23, bn,          step_asset_config_default_frozen(), {"Default frozen", text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 24, bnnn_paging, step_asset_config_unitname(),       {"Unit name",      text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 25, bn,          step_asset_config_decimals(),       {"Decimals",       text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 26, bnnn_paging, step_asset_config_assetname(),      {"Asset name",     text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 27, bnnn_paging, step_asset_config_url(),            {"URL",            text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 28, bnnn_paging, step_asset_config_metadata_hash(),  {"Metadata hash",  text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 29, bnnn_paging, step_asset_config_manager(),        {"Manager",        text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 30, bnnn_paging, step_asset_config_reserve(),        {"Reserve",        text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 31, bnnn_paging, step_asset_config_freeze(),         {"Freezer",        text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 32, bnnn_paging, step_asset_config_clawback(),       {"Clawback",       text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 24, bn,          step_asset_config_id(),             {"Asset ID",       text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 25, bn,          step_asset_config_total(),          {"Total units",    text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 26, bn,          step_asset_config_default_frozen(), {"Default frozen", text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 27, bnnn_paging, step_asset_config_unitname(),       {"Unit name",      text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 28, bn,          step_asset_config_decimals(),       {"Decimals",       text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 29, bnnn_paging, step_asset_config_assetname(),      {"Asset name",     text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 30, bnnn_paging, step_asset_config_url(),            {"URL",            text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 31, bnnn_paging, step_asset_config_metadata_hash(),  {"Metadata hash",  text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 32, bnnn_paging, step_asset_config_manager(),        {"Manager",        text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 33, bnnn_paging, step_asset_config_reserve(),        {"Reserve",        text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 34, bnnn_paging, step_asset_config_freeze(),         {"Freezer",        text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 35, bnnn_paging, step_asset_config_clawback(),       {"Clawback",       text});
 
-ALGO_UX_STEP(33, pbb, NULL, 0, txn_approve(), NULL, {&C_icon_validate_14, "Sign",   "transaction"});
-ALGO_UX_STEP(34, pbb, NULL, 0, txn_deny(),    NULL, {&C_icon_crossmark,   "Cancel", "signature"});
+ALGO_UX_STEP(36, pbb, NULL, 0, txn_approve(), NULL, {&C_icon_validate_14, "Sign",   "transaction"});
+ALGO_UX_STEP(37, pbb, NULL, 0, txn_deny(),    NULL, {&C_icon_crossmark,   "Cancel", "signature"});
 
 const ux_flow_step_t * const ux_txn_flow [] = {
   &txn_flow_0,
@@ -434,6 +456,9 @@ const ux_flow_step_t * const ux_txn_flow [] = {
   &txn_flow_32,
   &txn_flow_33,
   &txn_flow_34,
+  &txn_flow_35,
+  &txn_flow_36,
+  &txn_flow_37,
   FLOW_END_STEP,
 };
 #endif // TARGET_NANOX
@@ -451,39 +476,42 @@ struct ux_step {
 
 static unsigned int ux_current_step;
 static const struct ux_step ux_steps[] = {
-  { ALL_TYPES,    "Txn type",       &step_txn_type },
-  { ALL_TYPES,    "Sender",         &step_sender },
-  { ALL_TYPES,    "Fee (uAlg)",     &step_fee },
-  { ALL_TYPES,    "First valid",    &step_firstvalid },
-  { ALL_TYPES,    "Last valid",     &step_lastvalid },
-  { ALL_TYPES,    "Genesis ID",     &step_genesisID },
-  { ALL_TYPES,    "Genesis hash",   &step_genesisHash },
-  { ALL_TYPES,    "Note",           &step_note },
-  { PAYMENT,      "Receiver",       &step_receiver },
-  { PAYMENT,      "Amount (uAlg)",  &step_amount },
-  { PAYMENT,      "Close to",       &step_close },
-  { KEYREG,       "Vote PK",        &step_votepk },
-  { KEYREG,       "VRF PK",         &step_vrfpk },
-  { ASSET_XFER,   "Asset ID",       &step_asset_xfer_id },
-  { ASSET_XFER,   "Asset amt",      &step_asset_xfer_amount },
-  { ASSET_XFER,   "Asset src",      &step_asset_xfer_sender },
-  { ASSET_XFER,   "Asset dst",      &step_asset_xfer_receiver },
-  { ASSET_XFER,   "Asset close",    &step_asset_xfer_close },
-  { ASSET_FREEZE, "Asset ID",       &step_asset_freeze_id },
-  { ASSET_FREEZE, "Asset account",  &step_asset_freeze_account },
-  { ASSET_FREEZE, "Freeze flag",    &step_asset_freeze_flag },
-  { ASSET_CONFIG, "Asset ID",       &step_asset_config_id },
-  { ASSET_CONFIG, "Total units",    &step_asset_config_total },
-  { ASSET_CONFIG, "Default frozen", &step_asset_config_default_frozen },
-  { ASSET_CONFIG, "Unit name",      &step_asset_config_unitname },
-  { ASSET_CONFIG, "Decimals",       &step_asset_config_decimals },
-  { ASSET_CONFIG, "Asset name",     &step_asset_config_assetname },
-  { ASSET_CONFIG, "URL",            &step_asset_config_url },
-  { ASSET_CONFIG, "Metadata hash",  &step_asset_config_metadata_hash },
-  { ASSET_CONFIG, "Manager",        &step_asset_config_manager },
-  { ASSET_CONFIG, "Reserve",        &step_asset_config_reserve },
-  { ASSET_CONFIG, "Freezer",        &step_asset_config_freeze },
-  { ASSET_CONFIG, "Clawback",       &step_asset_config_clawback },
+  { ALL_TYPES,    "Txn type",         &step_txn_type },
+  { ALL_TYPES,    "Sender",           &step_sender },
+  { ALL_TYPES,    "Fee (uAlg)",       &step_fee },
+  { ALL_TYPES,    "First valid",      &step_firstvalid },
+  { ALL_TYPES,    "Last valid",       &step_lastvalid },
+  { ALL_TYPES,    "Genesis ID",       &step_genesisID },
+  { ALL_TYPES,    "Genesis hash",     &step_genesisHash },
+  { ALL_TYPES,    "Note",             &step_note },
+  { PAYMENT,      "Receiver",         &step_receiver },
+  { PAYMENT,      "Amount (uAlg)",    &step_amount },
+  { PAYMENT,      "Close to",         &step_close },
+  { KEYREG,       "Vote PK",          &step_votepk },
+  { KEYREG,       "VRF PK",           &step_vrfpk },
+  { KEYREG,       "Vote first",       &step_votefirst },
+  { KEYREG,       "Vote last",        &step_votelast },
+  { KEYREG,       "Nonparticipating", &step_nonpart },
+  { ASSET_XFER,   "Asset ID",         &step_asset_xfer_id },
+  { ASSET_XFER,   "Asset amt",        &step_asset_xfer_amount },
+  { ASSET_XFER,   "Asset src",        &step_asset_xfer_sender },
+  { ASSET_XFER,   "Asset dst",        &step_asset_xfer_receiver },
+  { ASSET_XFER,   "Asset close",      &step_asset_xfer_close },
+  { ASSET_FREEZE, "Asset ID",         &step_asset_freeze_id },
+  { ASSET_FREEZE, "Asset account",    &step_asset_freeze_account },
+  { ASSET_FREEZE, "Freeze flag",      &step_asset_freeze_flag },
+  { ASSET_CONFIG, "Asset ID",         &step_asset_config_id },
+  { ASSET_CONFIG, "Total units",      &step_asset_config_total },
+  { ASSET_CONFIG, "Default frozen",   &step_asset_config_default_frozen },
+  { ASSET_CONFIG, "Unit name",        &step_asset_config_unitname },
+  { ASSET_CONFIG, "Decimals",         &step_asset_config_decimals },
+  { ASSET_CONFIG, "Asset name",       &step_asset_config_assetname },
+  { ASSET_CONFIG, "URL",              &step_asset_config_url },
+  { ASSET_CONFIG, "Metadata hash",    &step_asset_config_metadata_hash },
+  { ASSET_CONFIG, "Manager",          &step_asset_config_manager },
+  { ASSET_CONFIG, "Reserve",          &step_asset_config_reserve },
+  { ASSET_CONFIG, "Freezer",          &step_asset_config_freeze },
+  { ASSET_CONFIG, "Clawback",         &step_asset_config_clawback },
 };
 
 static const bagl_element_t bagl_ui_approval_nanos[] = {

--- a/src/ui_txn.c
+++ b/src/ui_txn.c
@@ -81,6 +81,17 @@ static int step_sender() {
   return 1;
 }
 
+static int step_rekey() {
+  if (all_zero_key(current_txn.rekey)) {
+    return 0;
+  }
+
+  char checksummed[65];
+  checksummed_addr(current_txn.rekey, checksummed);
+  ui_text_put(checksummed);
+  return 1;
+}
+
 static int step_fee() {
   ui_text_put(u64str(current_txn.fee));
   return 1;
@@ -377,48 +388,49 @@ static unsigned int ux_last_step;
 
 ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 0, bn,          step_txn_type(),    {"Txn type",     text});
 ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 1, bnnn_paging, step_sender(),      {"Sender",       text});
-ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 2, bn,          step_fee(),         {"Fee (uAlg)",   text});
-ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 3, bn,          step_firstvalid(),  {"First valid",  text});
-ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 4, bn,          step_lastvalid(),   {"Last valid",   text});
-ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 5, bn,          step_genesisID(),   {"Genesis ID",   text});
-ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 6, bnnn_paging, step_genesisHash(), {"Genesis hash", text});
-ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 7, bn,          step_note(),        {"Note",         text});
+ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 2, bnnn_paging, step_rekey(),       {"RekeyTo",      text});
+ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 3, bn,          step_fee(),         {"Fee (uAlg)",   text});
+ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 4, bn,          step_firstvalid(),  {"First valid",  text});
+ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 5, bn,          step_lastvalid(),   {"Last valid",   text});
+ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 6, bn,          step_genesisID(),   {"Genesis ID",   text});
+ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 7, bnnn_paging, step_genesisHash(), {"Genesis hash", text});
+ALGO_UX_STEP_NOCB_INIT(ALL_TYPES, 8, bn,          step_note(),        {"Note",         text});
 
-ALGO_UX_STEP_NOCB_INIT(PAYMENT, 8,  bnnn_paging, step_receiver(), {"Receiver",      text});
-ALGO_UX_STEP_NOCB_INIT(PAYMENT, 9,  bn,          step_amount(),   {"Amount (uAlg)", text});
-ALGO_UX_STEP_NOCB_INIT(PAYMENT, 10, bnnn_paging, step_close(),    {"Close to",      text});
+ALGO_UX_STEP_NOCB_INIT(PAYMENT, 9,  bnnn_paging, step_receiver(), {"Receiver",      text});
+ALGO_UX_STEP_NOCB_INIT(PAYMENT, 10, bn,          step_amount(),   {"Amount (uAlg)", text});
+ALGO_UX_STEP_NOCB_INIT(PAYMENT, 11, bnnn_paging, step_close(),    {"Close to",      text});
 
-ALGO_UX_STEP_NOCB_INIT(KEYREG, 11, bnnn_paging, step_votepk(),    {"Vote PK",          text});
-ALGO_UX_STEP_NOCB_INIT(KEYREG, 12, bnnn_paging, step_vrfpk(),     {"VRF PK",           text});
-ALGO_UX_STEP_NOCB_INIT(KEYREG, 13, bn,          step_votefirst(), {"Vote first",       text});
-ALGO_UX_STEP_NOCB_INIT(KEYREG, 14, bn,          step_votelast(),  {"Vote last",        text});
-ALGO_UX_STEP_NOCB_INIT(KEYREG, 15, bn,          step_nonpart(),   {"Nonparticipating", text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 12, bnnn_paging, step_votepk(),    {"Vote PK",          text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 13, bnnn_paging, step_vrfpk(),     {"VRF PK",           text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 14, bn,          step_votefirst(), {"Vote first",       text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 15, bn,          step_votelast(),  {"Vote last",        text});
+ALGO_UX_STEP_NOCB_INIT(KEYREG, 16, bn,          step_nonpart(),   {"Nonparticipating", text});
 
-ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 16, bn,          step_asset_xfer_id(),       {"Asset ID",   text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 17, bn,          step_asset_xfer_amount(),   {"Asset amt",   text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 18, bnnn_paging, step_asset_xfer_sender(),   {"Asset src",   text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 19, bnnn_paging, step_asset_xfer_receiver(), {"Asset dst",   text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 20, bnnn_paging, step_asset_xfer_close(),    {"Asset close", text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 17, bn,          step_asset_xfer_id(),       {"Asset ID",   text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 18, bn,          step_asset_xfer_amount(),   {"Asset amt",   text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 19, bnnn_paging, step_asset_xfer_sender(),   {"Asset src",   text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 20, bnnn_paging, step_asset_xfer_receiver(), {"Asset dst",   text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_XFER, 21, bnnn_paging, step_asset_xfer_close(),    {"Asset close", text});
 
-ALGO_UX_STEP_NOCB_INIT(ASSET_FREEZE, 21, bn,          step_asset_freeze_id(),      {"Asset ID",      text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_FREEZE, 22, bnnn_paging, step_asset_freeze_account(), {"Asset account", text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_FREEZE, 23, bn,          step_asset_freeze_flag(),    {"Freeze flag",   text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_FREEZE, 22, bn,          step_asset_freeze_id(),      {"Asset ID",      text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_FREEZE, 23, bnnn_paging, step_asset_freeze_account(), {"Asset account", text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_FREEZE, 24, bn,          step_asset_freeze_flag(),    {"Freeze flag",   text});
 
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 24, bn,          step_asset_config_id(),             {"Asset ID",       text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 25, bn,          step_asset_config_total(),          {"Total units",    text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 26, bn,          step_asset_config_default_frozen(), {"Default frozen", text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 27, bnnn_paging, step_asset_config_unitname(),       {"Unit name",      text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 28, bn,          step_asset_config_decimals(),       {"Decimals",       text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 29, bnnn_paging, step_asset_config_assetname(),      {"Asset name",     text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 30, bnnn_paging, step_asset_config_url(),            {"URL",            text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 31, bnnn_paging, step_asset_config_metadata_hash(),  {"Metadata hash",  text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 32, bnnn_paging, step_asset_config_manager(),        {"Manager",        text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 33, bnnn_paging, step_asset_config_reserve(),        {"Reserve",        text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 34, bnnn_paging, step_asset_config_freeze(),         {"Freezer",        text});
-ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 35, bnnn_paging, step_asset_config_clawback(),       {"Clawback",       text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 25, bn,          step_asset_config_id(),             {"Asset ID",       text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 26, bn,          step_asset_config_total(),          {"Total units",    text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 27, bn,          step_asset_config_default_frozen(), {"Default frozen", text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 28, bnnn_paging, step_asset_config_unitname(),       {"Unit name",      text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 29, bn,          step_asset_config_decimals(),       {"Decimals",       text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 30, bnnn_paging, step_asset_config_assetname(),      {"Asset name",     text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 31, bnnn_paging, step_asset_config_url(),            {"URL",            text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 32, bnnn_paging, step_asset_config_metadata_hash(),  {"Metadata hash",  text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 33, bnnn_paging, step_asset_config_manager(),        {"Manager",        text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 34, bnnn_paging, step_asset_config_reserve(),        {"Reserve",        text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 35, bnnn_paging, step_asset_config_freeze(),         {"Freezer",        text});
+ALGO_UX_STEP_NOCB_INIT(ASSET_CONFIG, 36, bnnn_paging, step_asset_config_clawback(),       {"Clawback",       text});
 
-ALGO_UX_STEP(36, pbb, NULL, 0, txn_approve(), NULL, {&C_icon_validate_14, "Sign",   "transaction"});
-ALGO_UX_STEP(37, pbb, NULL, 0, txn_deny(),    NULL, {&C_icon_crossmark,   "Cancel", "signature"});
+ALGO_UX_STEP(37, pbb, NULL, 0, txn_approve(), NULL, {&C_icon_validate_14, "Sign",   "transaction"});
+ALGO_UX_STEP(38, pbb, NULL, 0, txn_deny(),    NULL, {&C_icon_crossmark,   "Cancel", "signature"});
 
 const ux_flow_step_t * const ux_txn_flow [] = {
   &txn_flow_0,
@@ -459,6 +471,7 @@ const ux_flow_step_t * const ux_txn_flow [] = {
   &txn_flow_35,
   &txn_flow_36,
   &txn_flow_37,
+  &txn_flow_38,
   FLOW_END_STEP,
 };
 #endif // TARGET_NANOX
@@ -478,6 +491,7 @@ static unsigned int ux_current_step;
 static const struct ux_step ux_steps[] = {
   { ALL_TYPES,    "Txn type",         &step_txn_type },
   { ALL_TYPES,    "Sender",           &step_sender },
+  { ALL_TYPES,    "RekeyTo",          &step_rekey },
   { ALL_TYPES,    "Fee (uAlg)",       &step_fee },
   { ALL_TYPES,    "First valid",      &step_firstvalid },
   { ALL_TYPES,    "Last valid",       &step_lastvalid },


### PR DESCRIPTION
In a separate branch I experimented with using the UX flow api (as used on the Nano X) on the Nano S, but ran into some issues when calling `txn_approve`.

I also switched us to using `-Oz`, which is like `-Os` but more aggressive.