### PR TITLE
Increase number of ASAs supported on Ledger

### DIFF
--- a/src/algo_asa.c
+++ b/src/algo_asa.c
@@ -34,6 +34,9 @@ static const algo_asset_info_t algo_assets[] = {
     ALGO_ASA(27165954, "PLANET",                    "PLANETS",     6),       
     ALGO_ASA(163650, "Asia Reserve Currency Coin",  "ARCC",        6),
     ALGO_ASA(137594422, "HEADLINE",                 "HDL",         6),
+    ALGO_ASA(142838028, "AlgoFam",                  "FAME",        6),
+    ALGO_ASA(226701642, "Yieldly",                  "YLDY",        6),
+    
 };
 
 


### PR DESCRIPTION
Increase number of ASAs supported on Ledger including ALGOFAM and Yieldly, 2 verified assets.